### PR TITLE
Fixed error key in doPost() (#887)

### DIFF
--- a/zxingorg/src/main/java/com/google/zxing/web/DecodeServlet.java
+++ b/zxingorg/src/main/java/com/google/zxing/web/DecodeServlet.java
@@ -303,7 +303,7 @@ public final class DecodeServlet extends HttpServlet {
       return;
     } catch (IOException ioe) {
       log.info(ioe.toString());
-      errorResponse(request, response, "badurl");
+      errorResponse(request, response, "badimage");
       return;
     }
     Part fileUploadPart = null;


### PR DESCRIPTION
doPost() works only with badimage